### PR TITLE
Clean up st.cmd*

### DIFF
--- a/iocs/simDetectorIOC/iocBoot/iocHDF5Test/st.cmd
+++ b/iocs/simDetectorIOC/iocBoot/iocHDF5Test/st.cmd
@@ -1,4 +1,4 @@
-# Must have loaded envPaths via st.cmd.linux or st.cmd.win32
+# Must have loaded envPaths via st.cmd.*
 
 errlogInit(20000)
 

--- a/iocs/simDetectorIOC/iocBoot/iocHDF5Test/st.cmd.darwin
+++ b/iocs/simDetectorIOC/iocBoot/iocHDF5Test/st.cmd.darwin
@@ -1,4 +1,3 @@
-epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
 < envPaths.darwin
 < st.cmd
 

--- a/iocs/simDetectorIOC/iocBoot/iocHDF5Test/st.cmd.vxWorks
+++ b/iocs/simDetectorIOC/iocBoot/iocHDF5Test/st.cmd.vxWorks
@@ -4,7 +4,6 @@
 cd topbin
 ld < simDetectorApp.munch
 cd startup
-# Must have loaded envPaths via st.cmd.linux or st.cmd.win32
 
 errlogInit(20000)
 

--- a/iocs/simDetectorIOC/iocBoot/iocSimDetector/st.cmd.darwin
+++ b/iocs/simDetectorIOC/iocBoot/iocSimDetector/st.cmd.darwin
@@ -1,4 +1,3 @@
-epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
 < envPaths.darwin
 < st.cmd
 

--- a/iocs/simDetectorIOC/iocBoot/iocSimDetector/st_base.cmd
+++ b/iocs/simDetectorIOC/iocBoot/iocSimDetector/st_base.cmd
@@ -1,4 +1,4 @@
-# Must have loaded envPaths via st.cmd.linux or st.cmd.win32
+# Must have loaded envPaths via st.cmd*
 
 errlogInit(20000)
 


### PR DESCRIPTION
Generalize references to st.cmd.linux and st.cmd.win32 (which should
have been st.cmd.windows) as "st.cmd.*".

Do not set EPICS_CA_MAX_ARRAY_BYTES in st.cmd.darwin.  That environment
variable is not set in st.cmd.windows or st.cmd.linux, so it should not
be set in st.cmd.darwin either.  The system administrator or user should
set it appropriately elsewhere.

Remove an erroneous comment in st.cmd.vxWorks about needing to have
loaded envPaths via st.cmd.linux or st.cmd.win32.