### PR TITLE
Initialise pointers to NULL

### DIFF
--- a/simDetectorApp/src/simDetector.cpp
+++ b/simDetectorApp/src/simDetector.cpp
@@ -1037,8 +1037,7 @@ simDetector::simDetector(const char *portName, int maxSizeX, int maxSizeY, NDDat
                0, 0, /* No interfaces beyond those set in ADDriver.cpp */
                0, 1, /* ASYN_CANBLOCK=0, ASYN_MULTIDEVICE=0, autoConnect=1 */
                priority, stackSize),
-      pRaw_(NULL), xSine1_(0), xSine2_(0), ySine1_(0), ySine2_(0)
-
+      pRaw_(NULL), pBackground_(NULL), pRamp_(NULL), pPeak_(NULL), xSine1_(0), xSine2_(0), ySine1_(0), ySine2_(0)
 {
     int status = asynSuccess;
     char versionString[20];


### PR DESCRIPTION
A memory leak was fixed in #21 . I found this could cause seg faults when it tried to release a random memory address on the first Acquire here
```
libADBase.so!NDArrayPool::release(NDArrayPool * const this, NDArray * pArray) (/dls/science/users/scv17895/py-libraries/pvi/ADCore/ADApp/ADSrc/NDArrayPool.cpp:321)
libADBase.so!NDArray::release(NDArray * const this) (/dls/science/users/scv17895/py-libraries/pvi/ADCore/ADApp/ADSrc/NDArray.cpp:233)
libsimDetector.so!simDetector::computeImage(simDetector * const this) (/dls/science/users/scv17895/py-libraries/pvi/ADSimDetector/simDetectorApp/src/simDetector.cpp:628)
libsimDetector.so!simDetector::simTask(simDetector * const this) (/dls/science/users/scv17895/py-libraries/pvi/ADSimDetector/simDetectorApp/src/simDetector.cpp:777)
libCom.so.3.14!start_routine(void * arg) (/dls_sw/epics/R3.14.12.7/base/src/libCom/osi/os/posix/osdThread.c:389)
libpthread.so.0!start_thread (Unknown Source:0)
libc.so.6!clone (Unknown Source:0)
```
because it was passing these checks:
```
if (pBackground_) pBackground_->release();
if (pRamp_) pRamp_->release();
if (pPeak_) pPeak_->release();
```

