### PR TITLE
Base image timestamp off epicsTS instead of startTime

### DIFF
--- a/simDetectorApp/Db/simDetector.template
+++ b/simDetectorApp/Db/simDetector.template
@@ -9,6 +9,24 @@ include "ADBase.template"
 # Redefine the color mode choices from ADBase.template to only have those that the simDetector
 # driver supports.  Keep the same values (xxVL), but change the menu numbers.
 
+record(bo, "$(P)$(R)TimeStampMode")
+{
+   field(PINI, "YES")
+   field(DTYP, "asynInt32")
+   field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_TIME_STAMP_MODE")
+   field(ZNAM, "Camera")
+   field(ONAM, "EPICS")
+}
+
+record(bi, "$(P)$(R)TimeStampMode_RBV")
+{
+   field(DTYP, "asynInt32")
+   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_TIME_STAMP_MODE")
+   field(ZNAM, "Camera")
+   field(ONAM, "EPICS")
+   field(SCAN, "I/O Intr")
+}
+
 record(mbbo, "$(P)$(R)ColorMode")
 {
    field(ZRST, "Mono")

--- a/simDetectorApp/src/simDetector.cpp
+++ b/simDetectorApp/src/simDetector.cpp
@@ -827,9 +827,8 @@ void simDetector::simTask()
 
         /* Put the frame number and time stamp into the buffer */
         pImage->uniqueId = imageCounter;
-        pImage->timeStamp = startTime.secPastEpoch + startTime.nsec / 1.e9;
-        updateTimeStamp(&pImage->epicsTS);
 
+        updateTimeStamp(&pImage->epicsTS);
         getIntegerParam(SimTimeStampMode, &timeStampMode);
         if (timeStampMode == TimeStampCamera) {
             SimUint64_t timeStamp;

--- a/simDetectorApp/src/simDetector.h
+++ b/simDetectorApp/src/simDetector.h
@@ -5,6 +5,28 @@
 #define DRIVER_REVISION     9
 #define DRIVER_MODIFICATION 0
 
+#if defined (_MSC_VER)
+    // For Microsoft systems
+    typedef __int8              SimInt8_t;
+    typedef unsigned __int8     SimUint8_t;
+    typedef __int16             SimInt16_t;
+    typedef unsigned __int16    SimUint16_t;
+    typedef __int32             SimInt32_t;
+    typedef unsigned __int32    SimUint32_t;
+    typedef __int64             SimInt64_t;
+    typedef unsigned __int64    SimUint64_t;
+#else // for non MS or GNU compilers without any warranty for the size
+    typedef signed char         SimInt8_t;
+    typedef unsigned char       SimUint8_t;
+    typedef short               SimInt16_t;
+    typedef unsigned short      SimUint16_t;
+    typedef int                 SimInt32_t;
+    typedef unsigned int        SimUint32_t;
+    typedef long long           Simnt64_t;
+    typedef unsigned long long  SimUint64_t;
+
+#endif
+
 /** Simulation detector driver; demonstrates most of the features that areaDetector drivers can support. */
 class epicsShareClass simDetector : public ADDriver {
 public:
@@ -54,6 +76,7 @@ protected:
     int SimYSine2Amplitude;
     int SimYSine2Frequency;
     int SimYSine2Phase;
+    int SimTimeStampMode;
 
 private:
     /* These are the methods that are new to this class */
@@ -124,3 +147,4 @@ typedef enum {
 #define SimYSine2AmplitudeString      "SIM_YSINE2_AMPLITUDE"
 #define SimYSine2FrequencyString      "SIM_YSINE2_FREQUENCY"
 #define SimYSine2PhaseString          "SIM_YSINE2_PHASE"
+#define SimTimeStampModeString       "SIM_TIME_STAMP_MODE"


### PR DESCRIPTION
While testing an acquisition on an ADPilatus detector with @coretl we observed unchanging image timestamps between frames. The time stamp logic for ADPilatus resembles the logic here, which uses the start time for all timestamps.
e: can't re-open so will make a new pr