### PR TITLE
Base image time stamp off epicsTS not startTime

### DIFF
--- a/simDetectorApp/src/simDetector.cpp
+++ b/simDetectorApp/src/simDetector.cpp
@@ -822,8 +822,8 @@ void simDetector::simTask()
 
         /* Put the frame number and time stamp into the buffer */
         pImage->uniqueId = imageCounter;
-        pImage->timeStamp = startTime.secPastEpoch + startTime.nsec / 1.e9;
         updateTimeStamp(&pImage->epicsTS);
+        pImage->timeStamp = pImage->epicsTS.secPastEpoch + pImage->epicsTS.nsec/1e9;
 
         /* Get any attributes that have been defined for this driver */
         this->getAttributes(pImage->pAttributeList);


### PR DESCRIPTION
We noticed that all image timestamps coming from an ADPilatus acquisition were identical, and identified that ADSimDetector, ADPilatus and others (will check) have this logic. Have changed the time stamp update to resemble the EPICS mode timestamping from ADVimba.